### PR TITLE
Version 1.59.1

### DIFF
--- a/algorithms/calcBedLgc.m
+++ b/algorithms/calcBedLgc.m
@@ -247,7 +247,8 @@ for itrDay=1:length(selDays)
         bedFlags(embdBed48h(indKp))=1;
     end
 end
-
+% store primary/seconday bedtimes directly in runLsBL by converting runLsBL{1} to double
+runLsBL{1}=double(runLsBL{1});
 runLsBL{1}(runLsBL{1}==1)=bedFlags;
 
 % remove low scoring bedtimes from run-length-encoding

--- a/stats/genDlyTable.m
+++ b/stats/genDlyTable.m
@@ -59,7 +59,8 @@ endDay=dateshift(dateTimeDT(end),'start','day');
 
 % if for some case data ends exactly at midnight, endDay should actually be the previous day
 if endDay==dateTimeDT(end)
-    endDay=endDay-days(1);
+    qcMeta(datetime(qcMeta.Start)==endDay,:)=[]; %remove the last day from daily-qc table
+    endDay=endDay-days(1); % select the previous day as the end day
 end
 
 %check whether stat domains is empty


### PR DESCRIPTION
#############################################
ActiPASS Version 1.59.1 (2023-09-03)
#############################################

*********** Bugfixes  ***************
1. Fixed a major bug in Bedtime/Sleep module. 
   The secondary bedtimes (or possible extra bedtimes) were treated as primary bedtimes because of a typecasting issue.
   This bug has been present since version 1.50 undetected. 
2. Fixed a bug in stats-generation when a mesurement ends exactly at midnight and auto-trimming is disabled
